### PR TITLE
Get rid of an implicit declaration warning

### DIFF
--- a/minicsv-test.c
+++ b/minicsv-test.c
@@ -1,5 +1,6 @@
 
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "minicsv.h"
 


### PR DESCRIPTION
This commit adds an include directive to get rid an implicit declaration
warning. The warning is caused by the usage of the `abort` standard
library function.